### PR TITLE
Base Image Update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM node:0.10
+FROM node:14-alpine
 
 MAINTAINER Torben Weibert <tw@mairlist.com>
 
-RUN npm -g install coffee-script
-RUN apt-get update && apt-get -y install curl lame
+RUN npm -g --production install coffeescript && \
+    apk --no-cache add lame curl && \
+    rm -rf /tmp/* /var/cache/apk/*
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ Then run the container, binding the HTTP port (8000), and passing the stream URL
 (in dBFS) as environment variables:
 
     docker run -p 8000:8000 -e STREAM_URL=http://sender.eldoradio.de:8000/192 \
-                            -e SILENCE_THRESHOLD=-20 mairlist/streammonitor
+                            -e SILENCE_THRESHOLD=-20 -e CHECK_INTERVAL=1000 \
+                            mairlist/streammonitor 
 
 ``STREAM_URL`` is a required parameter. ``SILENCE_THRESHOLD`` can be ommited, in which case
--20 dBFS is assumed.
+-20 dBFS is assumed. ``CHECK_INTERVAL`` is also optional and defaults to 1000 ms.
 
 The stream URL must be the actual URL for the stream (where the MP3 data is delivered),
 **not** the URL of a pls/m3u file.

--- a/app/app.coffee
+++ b/app/app.coffee
@@ -1,4 +1,4 @@
-require "coffee-script"
+require "coffeescript"
 net = require "net"
 express = require "express"
 http = require "http"

--- a/app/app.coffee
+++ b/app/app.coffee
@@ -15,6 +15,7 @@ child = null
 streamUrl = process.env.STREAM_URL
 silenceThreshold = process.env.SILENCE_THRESHOLD or -20
 httpPort = process.env.HTTP_PORT or 8000
+checkInterval = process.env.CHECK_INTERVAL or 1000
 
 # Config check
 unless streamUrl
@@ -95,4 +96,4 @@ server.listen 8000
 console.log "Stream monitor for %s started on port %d", streamUrl, httpPort
 
 # Start periodic check for child process
-setInterval checkChildProcess, 1000
+setInterval checkChildProcess, checkInterval

--- a/app/package.json
+++ b/app/package.json
@@ -4,7 +4,7 @@
   "description": "A monitor/silence detector for Icecast/Shoutcast streams",
   "main": "app.coffee",
   "dependencies": {
-    "coffee-script": "^1.9.3",
+    "coffeescript": "^1.9.3",
     "express": "^4.12.4"
   },
   "scripts": {


### PR DESCRIPTION
Hi,

- [x] Switching to current Node 14 Container with Alpine System.
- [x] Updated coffee-script repo name
- [x] Added optional checkInterval setting

Container size is now at 125MB instead of 655MB

This also fixes a memory in leak in coffeeskript or node - memory usage is now <33MB most of the time.